### PR TITLE
docs: clarify TradingNodeBuilder logger

### DIFF
--- a/nautilus_trader/live/node_builder.py
+++ b/nautilus_trader/live/node_builder.py
@@ -52,9 +52,7 @@ class TradingNodeBuilder:
     clock : LiveClock
         The clock for building clients.
     logger : Logger
-        The logger for building clients.
-    log : Logger
-        The trading nodes logger.
+        The logger for building clients and the trading node.
 
     """
 


### PR DESCRIPTION
## Summary
- clarify TradingNodeBuilder logger docstring

## Testing
- `pre-commit run --files nautilus_trader/live/node_builder.py`
- `pytest tests/unit_tests/live -q` *(fails: ModuleNotFoundError: No module named 'nautilus_trader.core.data')*


------
https://chatgpt.com/codex/tasks/task_e_6898c23ba378832a9ecc9458f771f9fb