### PR TITLE
fix: allow numeric rust toolchain versions

### DIFF
--- a/build.py
+++ b/build.py
@@ -143,12 +143,21 @@ def _set_feature_flags() -> list[str]:
     return flags
 
 
+def _is_valid_toolchain(toolchain: str) -> bool:
+    """
+    Return whether the given Rust toolchain specifier is valid.
+    """
+    return (
+        toolchain in ("stable", "nightly") or re.fullmatch(r"\d+\.\d+\.\d+", toolchain) is not None
+    )
+
+
 def _build_rust_libs() -> None:
     print("Compiling Rust libraries...")
 
     try:
         # Build the Rust libraries using Cargo
-        if RUSTUP_TOOLCHAIN not in ("stable", "nightly"):
+        if not _is_valid_toolchain(RUSTUP_TOOLCHAIN):
             raise ValueError(f"Invalid `RUSTUP_TOOLCHAIN` '{RUSTUP_TOOLCHAIN}'")
 
         needed_crates = [

--- a/tests_build/test_build_toolchain.py
+++ b/tests_build/test_build_toolchain.py
@@ -1,0 +1,19 @@
+import importlib.util
+from pathlib import Path
+
+
+spec = importlib.util.spec_from_file_location(
+    "build_module",
+    Path(__file__).resolve().parents[1] / "build.py",
+)
+assert spec and spec.loader
+build = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(build)
+
+
+def test_accepts_explicit_version():
+    assert build._is_valid_toolchain("1.87.0")
+
+
+def test_rejects_invalid_toolchain():
+    assert not build._is_valid_toolchain("beta")


### PR DESCRIPTION
## Summary
- allow numeric Rust toolchain strings in build script
- add unit test for `_is_valid_toolchain`

## Testing
- `pre-commit run --files build.py tests_build/test_build_toolchain.py`
- `pytest tests_build/test_build_toolchain.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c0722de0832aa76202b5f8f9c1dc